### PR TITLE
Use kubectl from bastion host

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/
 
 ## Use Kubernetes
 
-Terraform will output a command to connect to the master node at the end of the run.
-The Kubernetes configuration was copied on the master node to the user's home directory.
+Terraform will output a command to connect to the bastion node at the end of the run.
+The Kubernetes configuration was copied on the bastion node to the user's home directory.
 With this user, you should be able to run `kubectl` commands. For example, at the end of
 the Terraform run, try executing `kubectl get nodes` to see if all workers have joined
 the cluster successfully, and `kubectl get pods --namespace kube-system` to make sure all

--- a/public.tf
+++ b/public.tf
@@ -66,6 +66,19 @@ resource "null_resource" "test_bastion" {
     inline = [ "ls" ]
   }
 
+  provisioner "file" {
+    content      = "${tls_private_key.ssh_key.private_key_pem}"
+    destination = "/home/${var.username}/.ssh/id_rsa"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+        "mkdir -p /home/${var.username}/.kube",
+        "chmod 400 /home/${var.username}/.ssh/id_rsa",
+        "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${cloudca_instance.master_node.private_ip}:/home/${var.username}/.kube/config /home/${var.username}/.kube/config"
+    ]
+  }
+
   connection {
     type        = "ssh"
     host        = "${cloudca_public_ip.bastion.ip_address}"
@@ -73,4 +86,5 @@ resource "null_resource" "test_bastion" {
     private_key = "${tls_private_key.ssh_key.private_key_pem}"
     port        = 22
   }
+
 }

--- a/templates/cloudinit_bastion.tpl
+++ b/templates/cloudinit_bastion.tpl
@@ -14,4 +14,13 @@ users:
     lock_passwd: true
     ssh_authorized_keys:
       - "${public_key}"
+yum_repos:
+    kubernetes:
+      name: Kubernetes
+      baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+      enabled: true
+      gpgcheck: true
+      gpgkey: https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 
+runcmd:
+  - yum install -y kubectl


### PR DESCRIPTION
Allows you to use kubectl directly from the bastion host.

```
syed@syed-X230: ~/work/terraform-kubeadm (master) $ ssh -i id_rsa kubernetes@69.196.164.153
Last login: Mon Jun  4 17:54:07 2018 from 74.121.244.4
[kubernetes@kata-gvisor-bastion01 ~]$ kubectl get nodes
NAME                   STATUS    ROLES     AGE       VERSION
kata-gvisor-master01   Ready     master    11m       v1.10.3
kata-gvisor-worker01   Ready     <none>    11m       v1.10.3
[kubernetes@kata-gvisor-bastion01 ~]$ 
```